### PR TITLE
Fix mis-handling of Condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/cfn-flip/compare/v0.1.0.2...main)
+## [_Unreleased_](https://github.com/freckle/cfn-flip/compare/v0.1.0.3...main)
 
-None
+## [v0.1.0.3](https://github.com/freckle/cfn-flip/compare/v0.1.0.2...v0.1.0.3)
+
+- Fix mis-handling of `Condition` property
 
 ## [v0.1.0.1](https://github.com/freckle/cfn-flip/compare/v0.1.0.1...v0.1.0.2)
 

--- a/cfn-flip.cabal
+++ b/cfn-flip.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           cfn-flip
-version:        0.1.0.2
+version:        0.1.0.3
 synopsis:       Haskell implementation of aws/cfn-flip
 description:    Functions to flip between CloudFormation Yaml and JSON syntaxes
 category:       Tools

--- a/cfn-flip.cabal
+++ b/cfn-flip.cabal
@@ -19,6 +19,7 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     test/examples/clean.json
+    test/examples/condition.json
     test/examples/get-att.json
     test/examples/import_value.json
     test/examples/test.json
@@ -35,6 +36,7 @@ extra-source-files:
     test/examples/test_yaml_long_line.json
     test/examples/test_yaml_state_machine.json
     test/examples/clean.yaml
+    test/examples/condition.yaml
     test/examples/get-att.yaml
     test/examples/import_value.yaml
     test/examples/test.yaml

--- a/cfn-flip.cabal
+++ b/cfn-flip.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -105,13 +105,13 @@ library
     , unliftio
     , unliftio-core
     , yaml
+  default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)
     default-extensions:
         DerivingVia
     ghc-options: -fwrite-ide-info -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
-  default-language: Haskell2010
 
 test-suite doctest
   type: exitcode-stdio-1.0
@@ -149,13 +149,13 @@ test-suite doctest
     , base >=4.11 && <10
     , doctest
     , yaml
+  default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)
     default-extensions:
         DerivingVia
     ghc-options: -fwrite-ide-info -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
-  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -198,10 +198,10 @@ test-suite spec
     , filepath
     , hspec
     , libyaml
+  default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
   if impl(ghc >= 8.10)
     default-extensions:
         DerivingVia
     ghc-options: -fwrite-ide-info -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
-  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: cfn-flip
-version: 0.1.0.2
+version: 0.1.0.3
 github: "freckle/cfn-flip"
 license: MIT
 author: "Freckle R&D"

--- a/src/CfnFlip/IntrinsicFunction.hs
+++ b/src/CfnFlip/IntrinsicFunction.hs
@@ -38,7 +38,6 @@ intrinsics = map
   [ "And"
   , "Base64"
   , "Cidr"
-  , "Condition"
   , "Equals"
   , "FindInMap"
   , "GetAtt"
@@ -56,7 +55,7 @@ intrinsics = map
   ]
  where
   toFn x
-    | x `elem` ["Ref", "Condition"] = ("!" <> unpack x, encodeUtf8 x)
+    | x == "Ref" = ("!" <> unpack x, encodeUtf8 x)
     | otherwise = ("!" <> unpack x, "Fn::" <> encodeUtf8 x)
 
 swappedIntrinsics :: [(ByteString, String)]

--- a/src/CfnFlip/Yaml.hs
+++ b/src/CfnFlip/Yaml.hs
@@ -8,7 +8,7 @@ module CfnFlip.Yaml
 
 import CfnFlip.Prelude
 
-import CfnFlip.Aeson (ToJSON(..))
+import CfnFlip.Aeson (ToJSON)
 import CfnFlip.Conduit
 import CfnFlip.IntrinsicFunction
 import CfnFlip.Libyaml
@@ -27,7 +27,7 @@ encode
   -> m ByteString
 encode c a =
   runConduitRes
-    $ sourceList (Yaml.objToStream stringStyle $ toJSON a)
+    $ sourceList (Yaml.objToStream stringStyle a)
     .| c
     .| fixQuoting
     .| Libyaml.encodeWith formatOptions

--- a/test/examples/condition.json
+++ b/test/examples/condition.json
@@ -1,0 +1,8 @@
+{
+  "Resources": {
+    "ApiStage": {
+      "Condition": "HasHttpApi",
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/test/examples/condition.yaml
+++ b/test/examples/condition.yaml
@@ -1,0 +1,4 @@
+Resources:
+  ApiStage:
+    Condition: HasHttpApi
+    Type: AWS::ApiGateway::Stage


### PR DESCRIPTION
`Condition` is not an intrinsic function in the same way as the others;
it does not need special handling as the start of a mapping, nor to be
translated to/from `!Condition`. In fact, as far as the encoding and
flip is concerned, it's just another opaque key-value.

This bug only hasn't impacted us yet because all our current use-cases
have the `Condition` element coming out not-first in its enclosing
resource `MappingStart`; and this prevents it from being (mis-)handled
as the (non-existent) intrinsic `!Condition`.

By pure happenstance, the update to aeson-2.0 that just occurred in a
downstream application caused re-ordering of Object keys and placed one
of our the `Condition` keys first in the resource, causing us to hit
this bug. What's more, the result of the bug is a completely blank
string coming out the other side!